### PR TITLE
log files are no longer deleted when more spec files runs

### DIFF
--- a/plugin/plugin.js
+++ b/plugin/plugin.js
@@ -15,6 +15,9 @@ function install(on, _config) {
             return writeLogs(filePath, content);
         }
     });
+    on("before:run", function (details) {
+        clearFiles(details.config["smart-logs-folder"] || "cypress/smart-logs");
+    });
 }
 exports.install = install;
 function clearFiles(directory) {

--- a/plugin/plugin.ts
+++ b/plugin/plugin.ts
@@ -8,6 +8,9 @@ export function install(on: Cypress.PluginEvents, _config: Cypress.ConfigOptions
   on("task", {
     "write-smart-logs": ({ filePath, content }: { filePath: string; content: string }) => writeLogs(filePath, content),
   });
+  on("before:run", (details) => {
+    clearFiles(details.config["smart-logs-folder"] || "cypress/smart-logs");
+  });
 }
 
 function clearFiles(directory: string): null {

--- a/src/buffer.ts
+++ b/src/buffer.ts
@@ -4,10 +4,6 @@ import { writeFailedTestInfo as writeFileLogs } from "./fileUtils";
 
 export let buffer: IWithText[] = [];
 
-before(() =>
-  cy.task("clean-smart-logs", { path: Cypress.config("smart-logs-folder") || "cypress/smart-logs" }, { log: false })
-);
-
 const origDescribe = describe;
 
 function newDescribe(this: Suite, title: string): Suite;


### PR DESCRIPTION
Fixed problem with deleting log files between two (or more) spec files. When cypress runs with more files (cypress run a.spec.ts,b.spec.ts) log files from first spec file were deleted. 